### PR TITLE
Azure : Pre-install 2.x compatible python dependencies

### DIFF
--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -39,6 +39,8 @@ jobs:
 
    - script: |
         python --version
+        # Pre-installs some floating dependencies of the main modules that no longer support 2.x
+        pip install --user cryptography==2.9 &&
         pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub==1.45
      displayName: 'Install Python Modules'
 


### PR DESCRIPTION
Some of our version-locked packages install floating dependencies.
These are starting to phase out 2.x support (understandably). As such
we pre-install 2.x compatible versions before the requesting packages.
This will probably keep happening. We need to get infrastructure
running in 3.x at some point, even if its before we ship a 3.x Gaffer.
